### PR TITLE
Vf 259 add routing from tabs

### DIFF
--- a/app/components/routing-tabs.tsx
+++ b/app/components/routing-tabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import * as React from "react";
+import React from "react";
 import { useNavigate } from "react-router";
 
 type TabItem = {
@@ -11,15 +11,15 @@ type TabItem = {
 };
 
 type RoutingTabsProps = {
-  tabs?: TabItem[];
+  tabs?: Array<TabItem>;
   defaultValue?: string;
 };
 
 // Provide an array of { label, to } and the component will navigate when a tab is selected.
-export default function RoutingTabs({ tabs, defaultValue }: RoutingTabsProps) {
+export function RoutingTabs({ tabs, defaultValue }: RoutingTabsProps) {
   const navigate = useNavigate();
 
-  const defaultTabs: TabItem[] = React.useMemo(
+  const defaultTabs: Array<TabItem> = React.useMemo(
     () => [
       { label: "Søkere", to: "dashboard/sokere", value: "sokere" },
       {
@@ -34,7 +34,7 @@ export default function RoutingTabs({ tabs, defaultValue }: RoutingTabsProps) {
       },
       { label: "Intervjuer", to: "dashboard/intervjuer", value: "intervjuer" },
     ],
-    []
+    [],
   );
 
   const items = tabs ?? defaultTabs;
@@ -47,7 +47,7 @@ export default function RoutingTabs({ tabs, defaultValue }: RoutingTabsProps) {
   return (
     <Tabs
       value={defaultValue}
-      className="w-full max-w-7xl px-4 sm:px-6 lg:px-8 mb-6"
+      className="mb-6 w-full max-w-7xl px-4 sm:px-6 lg:px-8"
       onValueChange={handleTabChange}
     >
       <div className="flex justify-center">

--- a/app/routes/dashboard.intervjuer._index.tsx
+++ b/app/routes/dashboard.intervjuer._index.tsx
@@ -1,5 +1,4 @@
-import RoutingTabs from "@/components/routing-tabs";
-
+import { RoutingTabs } from "@/components/routing-tabs";
 // biome-ignore lint/style/noDefaultExport: Route Modules require default export https://reactrouter.com/start/framework/route-module
 export default function Intervjuer() {
   return (

--- a/app/routes/dashboard.intervjufordeling._index.tsx
+++ b/app/routes/dashboard.intervjufordeling._index.tsx
@@ -1,11 +1,11 @@
-import TabsNavigation from "@/components/routing-tabs";
+import { RoutingTabs } from "@/components/routing-tabs";
 
 // biome-ignore lint/style/noDefaultExport: Route Modules require default export https://reactrouter.com/start/framework/route-module
 export default function Intervjufordeling() {
   return (
     <>
       <h1>Intervjufordeling</h1>
-      <TabsNavigation defaultValue="intervjufordeling" />
+      <RoutingTabs defaultValue="intervjufordeling" />
     </>
   );
 }

--- a/app/routes/dashboard.sokere._index.tsx
+++ b/app/routes/dashboard.sokere._index.tsx
@@ -1,5 +1,5 @@
 import { DataTable } from "@/components/data-table";
-import RoutingTabs from "@/components/routing-tabs";
+import { RoutingTabs } from "@/components/routing-tabs";
 import { Checkbox } from "@/components/ui/checkbox";
 import type { ColumnDef } from "@tanstack/react-table";
 import { DataSokere } from "../mock/api/data-sokere";

--- a/app/routes/dashboard.tidligere-assistenter._index.tsx
+++ b/app/routes/dashboard.tidligere-assistenter._index.tsx
@@ -1,11 +1,11 @@
-import TabsNavigation from "@/components/routing-tabs";
+import { RoutingTabs } from "@/components/routing-tabs";
 
 // biome-ignore lint/style/noDefaultExport: Route Modules require default export https://reactrouter.com/start/framework/route-module
 export default function TidligereAssistenter() {
   return (
     <>
       <h1>Tidligere Assistenter</h1>
-      <TabsNavigation defaultValue="tidligere-assistenter" />
+      <RoutingTabs defaultValue="tidligere-assistenter" />
     </>
   );
 }

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -398,7 +398,7 @@ function Breadcrumbs() {
             to={`/${fullPath}`}
             className={cn(
               isEnd ? "text-black" : "text-gray-500",
-              "hover:text-black"
+              "hover:text-black",
             )}
             prefetch="intent"
           >


### PR DESCRIPTION
---
name: Pull Request
description: Create a pull request
title: VF-259 Add routing from tabs
---
### Describe your changes 📖
Created a routing tab component which uses default tabs if none are provided. The default tabs are the pages under "opptak" on the dashboard. They give you the ability to navigate to related pages through this tab without having to go trhough the sidebar.

### Linear ticket: 🔖

VF-259

### Checklist before requesting a review ✔️

- [] I have performed a self-review of my code
- [] I have verified that the code works as intended
- [] Pipeline runs successfully
- [] Tests passes
